### PR TITLE
ensure that the ssize_t_clean macro is included

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ source:
     - patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
     - patches/0004-Add-conda-forge-include-dirs-to-list-of-include-dirs.patch
     - patches/0005-Enable-usage-of-MLIR-tblgen.patch
+    - patches/0006-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
 
 build:
   number: 0

--- a/recipe/patches/0006-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
+++ b/recipe/patches/0006-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
@@ -1,0 +1,24 @@
+From 7b810e558ea7fce9e19356c634feb41167127119 Mon Sep 17 00:00:00 2001
+From: Aditya Mayukh Som <adi.kg2@gmail.com>
+Date: Sat, 24 May 2025 20:05:24 +0000
+Subject: [PATCH 5/5] fixes definition of PY_SSIZE_T_CLEAN macro
+
+[removed unnecessary changes]
+
+Co-Authored-By: H. Vetinari <h.vetinari@gmx.com>
+---
+ third_party/nvidia/backend/driver.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/third_party/nvidia/backend/driver.py b/third_party/nvidia/backend/driver.py
+index 5f2621ae5..3c59f2df5 100644
+--- a/third_party/nvidia/backend/driver.py
++++ b/third_party/nvidia/backend/driver.py
+@@ -196,6 +196,7 @@ def make_launcher(constants, signature):
+     params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
+     params.append("&global_scratch")
+     src = f"""
++#define PY_SSIZE_T_CLEAN
+ #include \"cuda.h\"
+ #include <stdbool.h>
+ #include <Python.h>


### PR DESCRIPTION
triton 3.3.0 - backport macro inclusion
destination: defaults

This fixes an issue when it comes to PY_SSIZE_T_CLEAN causing an issue on torchvision on python versions below 3.13. The patch is okay to apply on all versions. 

https://docs.python.org/3/c-api/arg.html#strings-and-buffers <- refer to this for more information 

Tests failing due to circular pytorch dependency 