### PR TITLE
3.5.1 Update

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -6,4 +6,4 @@ build_parameters:
   - "--no-test"
 
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,15 +20,15 @@ export TRITON_CUPTI_LIB_PATH=$PREFIX/lib
 export MAX_JOBS=$CPU_COUNT
 
 # Cleanup caches, helpful to avoid previous build leftovers during development.
-rm -rf /tmp/.triton/
-rm -rf ~/.triton/
-rm -rf /tmp/triton*
+rm -rf /tmp/.triton/ || true
+rm -rf ~/.triton/ || true
+rm -rf /tmp/triton* || true
 rm -rf build/
 rm -rf dist/
 rm -rf *.egg-info/
 
 # GCC version missing __glibcxx_assert_fail function. We'll create a stub for it.
-cat > /tmp/glibcxx_assert_stub.cpp << 'EOF'
+cat > $SRC_DIR/glibcxx_assert_stub.cpp << 'EOF'
 #include <cstdio>
 #include <cstdlib>
 
@@ -42,11 +42,11 @@ namespace std {
 EOF
 
 # Compile the stub into an object file
-$CXX -c /tmp/glibcxx_assert_stub.cpp -o /tmp/glibcxx_assert_stub.o -fPIC
+$CXX -c $SRC_DIR/glibcxx_assert_stub.cpp -o $SRC_DIR/glibcxx_assert_stub.o -fPIC
 
 export CXXFLAGS="-D_GLIBCXX_ASSERTIONS $CXXFLAGS"
 export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS"
-export LDFLAGS="/tmp/glibcxx_assert_stub.o -L$BUILD_PREFIX/lib -Wl,-rpath,$BUILD_PREFIX/lib $LDFLAGS"
+export LDFLAGS="$SRC_DIR/glibcxx_assert_stub.o -L$BUILD_PREFIX/lib -Wl,-rpath,$BUILD_PREFIX/lib $LDFLAGS"
 
 # the build does not run C++ unittests, and they implicitly fetch gtest
 # no easy way of passing this, not really worth a whole patch

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,9 +5,6 @@ set -ex
 # remove outdated vendored headers
 rm -rf $SRC_DIR/python/triton/third_party
 
-# disable downloading dependencies entirely
-export TRITON_OFFLINE_BUILD=1
-
 export JSON_SYSPATH=$PREFIX
 export PYBIND11_SYSPATH=$SP_DIR/pybind11
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,17 +5,21 @@ set -ex
 # remove outdated vendored headers
 rm -rf $SRC_DIR/python/triton/third_party
 
+# disable downloading dependencies entirely
+export TRITON_OFFLINE_BUILD=1
+
 export JSON_SYSPATH=$PREFIX
 export PYBIND11_SYSPATH=$SP_DIR/pybind11
 
-# these don't seem to be actually used, but they prevent downloads
+# only some of them are actually used currently, but set all just in case
 export TRITON_PTXAS_PATH=$PREFIX/bin/ptxas
 export TRITON_CUOBJDUMP_PATH=$PREFIX/bin/cuobjdump
 export TRITON_NVDISASM_PATH=$PREFIX/bin/nvdisasm
 export TRITON_CUDACRT_PATH=$PREFIX
-export TRITON_CUDART_PATH=$PREFIX/targets/x86_64-linux/include
-export TRITON_CUPTI_PATH=$PREFIX
-export TRITON_CACHE_DIR=/tmp/.triton
+export TRITON_CUDART_PATH=$PREFIX
+export TRITON_CUPTI_INCLUDE_PATH=$PREFIX/include
+export TRITON_CUPTI_LIB_PATH=$PREFIX/lib
+
 export MAX_JOBS=$CPU_COUNT
 
 # Cleanup caches, helpful to avoid previous build leftovers during development.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,3 +9,4 @@ libmlir:
 
 cuda_compiler_version:
   - 12.8
+  - 13.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,21 @@
-{% set version = "3.4.0" %}
+{% set version = "3.5.1" %}
 
 package:
   name: triton
   version: {{ version }}
 
 source:
-  url: https://github.com/triton-lang/triton/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a96e87a911794c907fab30e0c7a3f96ef4e9e8fdc8812cd8bbc6f0457619072f
+  url: https://github.com/triton-lang/triton/releases/download/v{{ version }}/triton-{{ version }}.tar.gz
+  sha256: 4afb7e2af6ab4585ea923eb5054ea1748989d3a4b5b2e035d239723924c8a7fa
   patches:
     - patches/0001-Remove-Werror-that-cause-false-positive-build-failur.patch
     - patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
     - patches/0004-Add-conda-forge-include-dirs-to-list-of-include-dirs.patch
     - patches/0006-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
+    - patches/0007-PROTON-Conditionally-include-Proton-tests-8237.patch
 
 build:
-  number: 1
+  number: 0
   # TODO: windows support should be available from next version;
   #       CPU-only support still under development
   skip: true  # [win or cuda_compiler_version == "None"]
@@ -34,15 +35,14 @@ requirements:
     - pybind11
     - pip
     - setuptools
-    - wheel
     - zlib
     - nlohmann_json
     - cuda-cupti-dev
+    - cuda-version {{ cuda_compiler_version }}.*
   run:
     - python
-    - filelock
-    - lit
-    - cuda-nvcc
+    - setuptools
+    - cuda-nvcc-tools
     - cuda-cuobjdump
     - cuda-cudart
     - cuda-cupti
@@ -63,10 +63,10 @@ test:
   commands:
     - pip check
     # test suite essentially depends on availability of a physical GPU,
-    # see https://github.com/openai/triton/issues/466;
+    # see https://github.com/triton-lang/triton/issues/466;
     # run a test that does not require a GPU but checks
     # if triton.compile() works
-    - pytest -v python/test/unit/tools/test_aot.py::test_ttgir_to_ptx
+    - TRITON_INTERPRET=1 pytest -v python/test/unit/tools/test_aot.py::test_ttgir_to_asm
     # Here is a list of current test failures and reasoning why they're ok:
     #
     # test_dummy_backend                    - looks like it's using CUDA instead of CPU backend for this test, for some reason. We don't need to use the CPU backend anyway.
@@ -84,7 +84,7 @@ test:
     - pytest -v python/test --ignore=python/test/regression/test_performance.py --ignore=python/test/backend/test_device_backend.py --ignore=python/test/unit || true
 
 about:
-  home: https://github.com/openai/triton
+  home: https://github.com/triton-lang/triton
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -93,7 +93,7 @@ about:
     This is the development repository of Triton, a language and compiler for writing highly efficient custom Deep-Learning primitives.
     The aim of Triton is to provide an open-source environment to write fast code at higher productivity than CUDA, but also with higher flexibility than other existing DSLs.
   doc_url: https://triton-lang.org/
-  dev_url: https://github.com/openai/triton
+  dev_url: https://github.com/triton-lang/triton
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - zlib
     - nlohmann_json
     - cuda-cupti-dev
-    - cuda-version {{ cuda_compiler_version }}.*
+    - cuda-version {{ cuda_compiler_version }}
   run:
     - python
     - cuda-nvcc-tools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - cuda-version {{ cuda_compiler_version }}
   run:
     - python
+    - setuptools
     - cuda-nvcc-tools
     - cuda-cuobjdump
     - cuda-cudart

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - cuda-version {{ cuda_compiler_version }}.*
   run:
     - python
-    - setuptools
     - cuda-nvcc-tools
     - cuda-cuobjdump
     - cuda-cudart

--- a/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
+++ b/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
@@ -1,17 +1,17 @@
-From 555b7e69d6fc4822b01386a24e2e84c46ac4c244 Mon Sep 17 00:00:00 2001
+From 602f2fa131453be86525be7844a7a0abe6e01ef9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@quansight.com>
 Date: Fri, 1 Aug 2025 13:31:58 +0200
 Subject: [PATCH 3/5] Use system PATH to find tools (in CONDA_PREFIX)
 
 ---
- python/triton/knobs.py | 2 ++
- 1 file changed, 2 insertions(+)
+ python/triton/knobs.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/python/triton/knobs.py b/python/triton/knobs.py
-index 30804b170..014e612bb 100644
+index 161f739bd..d492b3a46 100644
 --- a/python/triton/knobs.py
 +++ b/python/triton/knobs.py
-@@ -3,6 +3,7 @@ from __future__ import annotations
+@@ -4,6 +4,7 @@ import functools
  import importlib
  import os
  import re
@@ -19,11 +19,15 @@ index 30804b170..014e612bb 100644
  import subprocess
  import sysconfig
  
-@@ -202,6 +203,7 @@ class env_nvidia_tool(env_base[str, NvidiaTool]):
-             # We still add default as fallback in case the pointed binary isn't
-             # accessible.
-             self.default(),
-+            shutil.which(self.binary),
-         ]
+@@ -204,9 +205,9 @@ class env_nvidia_tool(env_base[str, NvidiaTool]):
+         # We still add default as fallback in case the pointed binary isn't
+         # accessible.
+         if path is not None:
+-            paths = [path, self.default_path]
++            paths = [path, self.default_path, shutil.which(self.binary)]
+         else:
+-            paths = [self.default_path]
++            paths = [self.default_path, shutil.which(self.binary)]
+ 
          for path in paths:
-             if not path or not os.access(path, os.X_OK):
+             if tool := NvidiaTool.from_path(path):

--- a/recipe/patches/0006-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
+++ b/recipe/patches/0006-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
@@ -1,4 +1,4 @@
-From 7b810e558ea7fce9e19356c634feb41167127119 Mon Sep 17 00:00:00 2001
+From 7b5f20ef823c5be699f50853725b47f177189d55 Mon Sep 17 00:00:00 2001
 From: Aditya Mayukh Som <adi.kg2@gmail.com>
 Date: Sat, 24 May 2025 20:05:24 +0000
 Subject: [PATCH 5/5] fixes definition of PY_SSIZE_T_CLEAN macro
@@ -11,14 +11,14 @@ Co-Authored-By: H. Vetinari <h.vetinari@gmx.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/third_party/nvidia/backend/driver.py b/third_party/nvidia/backend/driver.py
-index 5f2621ae5..3c59f2df5 100644
+index e6fd6a968..00dbb7758 100644
 --- a/third_party/nvidia/backend/driver.py
 +++ b/third_party/nvidia/backend/driver.py
-@@ -196,6 +196,7 @@ def make_launcher(constants, signature):
-     params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
+@@ -262,6 +262,7 @@ def make_launcher(constants, signature, tensordesc_meta):
      params.append("&global_scratch")
+     params.append("&profile_scratch")
      src = f"""
 +#define PY_SSIZE_T_CLEAN
  #include \"cuda.h\"
+ #include <dlfcn.h>
  #include <stdbool.h>
- #include <Python.h>

--- a/recipe/patches/0007-PROTON-Conditionally-include-Proton-tests-8237.patch
+++ b/recipe/patches/0007-PROTON-Conditionally-include-Proton-tests-8237.patch
@@ -1,0 +1,24 @@
+From ff21a9bb9376605f472e946e38fbfc0c8a8c4669 Mon Sep 17 00:00:00 2001
+From: joehutcheson <63621767+joehutcheson@users.noreply.github.com>
+Date: Mon, 22 Sep 2025 21:45:07 +0100
+Subject: [PATCH 6/6] [PROTON] Conditionally include Proton tests (#8237)
+
+Adds a condition on `TRITON_BUILD_UT` before including Proton tests.
+
+When `TRITON_BUILD_UT` is `OFF` without adding this condition, a build
+failure occurs. This is because the Proton tests cmake calls the
+`add_triton_ut` function, however this function is not declared when
+`TRITON_BUILD_UT` is `OFF`.
+---
+ third_party/proton/test/CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/third_party/proton/test/CMakeLists.txt b/third_party/proton/test/CMakeLists.txt
+index e250d49f2..5b05b0894 100644
+--- a/third_party/proton/test/CMakeLists.txt
++++ b/third_party/proton/test/CMakeLists.txt
+@@ -1 +1,3 @@
+-add_subdirectory(unittest)
++if(TRITON_BUILD_UT)
++  add_subdirectory(unittest)
++endif()


### PR DESCRIPTION
**triton 3.5.1 (linux)**

**Destination channel:** defaults

### Links
* Upstream repository: https://github.com/triton-lang/triton
* Upstream release: https://github.com/triton-lang/triton/releases/tag/v3.5.1

### Explanation of changes:

* **Version bump 3.4.0 → 3.5.1**, build number reset to 0. Source URL switched from GitHub archive tarball to the official release tarball.
* **Upstream URL migration:** All references updated from `openai/triton` to `triton-lang/triton` (home, dev_url, issue links).
* **Build script updates:**
  * CUPTI env vars split into `TRITON_CUPTI_INCLUDE_PATH` and `TRITON_CUPTI_LIB_PATH` (replacing single `TRITON_CUPTI_PATH`).
  * `TRITON_CUDART_PATH` simplified to `$PREFIX` (was architecture-specific `$PREFIX/targets/x86_64-linux/include`).
  * Removed `TRITON_CACHE_DIR` override.
* **Dependency changes:**
  * Host: removed `wheel`, added `cuda-version {{ cuda_compiler_version }}` pin.
  * Run: replaced `filelock`, `lit`, and `cuda-nvcc` with `setuptools` and `cuda-nvcc-tools`.
* **New patch `0007`:** Backport of upstream PR #8237 — wraps Proton test inclusion in a `TRITON_BUILD_UT` guard to prevent CMake build failures when unit tests are disabled.
* **Rebased existing patches** (0003, 0006) to apply cleanly against 3.5.1. Patch 0003 updated to match refactored `knobs.py` tool-path resolution logic.

### Testing
Testing for this repo is done via pytorch linux cuda tests. Due to circular dependency 
https://package-build.anaconda.com/v1/graph/887d6e8a-d871-4455-9083-905e04d2031a
