### PR TITLE
PKG-14950: rebuild triton 3.7.0 against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - python
     # upstream pyproject.toml requires pybind11>=2.13.1
     - pybind11 >=2.13.1
+    - pybind11-abi
     - pip
     - setuptools
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/0004-Add-conda-forge-include-dirs-to-list-of-include-dirs.patch
 
 build:
-  number: 0
+  number: 1
   # TODO: windows support should be available from next version;
   #       CPU-only support still under development
   skip: true  # [win or cuda_compiler_version == "None"]


### PR DESCRIPTION
triton 3.7.0

**Destination channel:** Defaults

### Links

- [PKG-14950](https://anaconda.atlassian.net/browse/PKG-14950)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Relevant dependency PRs:
  - AnacondaRecipes/pybind11-feedstock#24 (pybind11 3.0.4 — **MERGED, released to pkgs/main**)
  - AnacondaRecipes/repodata-hotfixes#318 (scope reduction — **applied**)

### Explanation of changes:

- **Build number 0 -> 1** (no source change). Rebuild against pybind11 3.0.4 from pkgs/main.
- **Result:** the new artifact will declare `pybind11-abi ==11` (via pybind11-abi's run_export) instead of the prior `==5` injected by repodata-hotfixes #316.
- **Why:** triton participates in cross-module C++ type exchange with pytorch (torch::Tensor handles). Per Charles's PKG-13552 hotfix-scope analysis, triton is retained in the slim `MISSING_PYBIND11_ABI_VERSION_RANGES` table after #318. This rebuild ensures triton on pkgs/main solves cleanly with pybind11-v3-built pytorch / torchvision / torchaudio in the same env.

[PKG-14950]: https://anaconda.atlassian.net/browse/PKG-14950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ