### PR TITLE
update to 3.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,23 @@
-{% set version = "3.7.0" %}
+{% set version = "3.7.1" %}
 
 package:
   name: triton
   version: {{ version }}
 
 source:
-  # Use the GitHub auto-archive instead of the official release tarball:
-  # triton-3.7.0.tar.gz (releases/download/...) is missing examples/plugins/,
-  # which CMakeLists.txt:342 references (add_subdirectory). The auto-archive
-  # contains the full repo tree. Triton has no real git submodules (backends
-  # nvidia/amd/proton are in-tree), so auto-archive works as the source.
+  # 3.7.1 added MANIFEST.in coverage for examples/ in the official release
+  # tarball (#10350), but stay on the GitHub auto-archive for consistency with
+  # the 3.7.0 recipe — Triton has no real git submodules (backends nvidia/amd/
+  # proton are in-tree), so auto-archive works as the source.
   url: https://github.com/triton-lang/triton/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: ff5cdcdd1b3f30a5db06c4e690ac73b16342c8181820e2cdf74e8514065ea7b8
+  sha256: 7d998625d1035ac496d06a81117727647169422ee67b8889609f06fd5367c491
   patches:
     - patches/0001-Remove-Werror-that-cause-false-positive-build-failur.patch
     - patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
     - patches/0004-Add-conda-forge-include-dirs-to-list-of-include-dirs.patch
 
 build:
-  number: 1
+  number: 0
   # TODO: windows support should be available from next version;
   #       CPU-only support still under development
   skip: true  # [win or cuda_compiler_version == "None"]


### PR DESCRIPTION
triton 3.7.1

**Destination channel:** defaults

### Links

- [PKG-15870](https://anaconda.atlassian.net/browse/PKG-15870)
- [Upstream repository](https://github.com/triton-lang/triton)
- [Upstream v3.7.1 release](https://github.com/triton-lang/triton/releases/tag/v3.7.1)
- [Upstream 3.7.0 → 3.7.1 diff](https://github.com/triton-lang/triton/compare/v3.7.0...v3.7.1)
- Required by:
  - [pytorch 2.12.1 release notes](https://github.com/pytorch/pytorch/releases/tag/v2.12.1) (cites the 3.7.0 → 3.7.1 bump as the fix for both Blackwell regressions)
  - pytorch 2.13.0 (PKG-12883 epic, GA ~2026-07-08) — `release/2.13` currently pins triton 1 commit behind v3.7.1; 3.7.1 fixes ride along once upstream cherry-picks

### Explanation of changes:

- **Version `3.7.0` → `3.7.1`** (released 2026-06-18). 4-commit patch release, Blackwell B100/B200 fixes only — no API changes:
  - ProxyFenceInsertion: add async-read deps to the pass (fixes [#181248](https://github.com/pytorch/pytorch/issues/181248) FLASH_ATTN nondeterminism on B200)
  - LLVM hash bumped to `triton-lang/llvm-project@1f126a6` (fixes [#187081](https://github.com/pytorch/pytorch/issues/187081) illegal memory access in `convolution2d_bwd_weight` on B100/B200)
  - MANIFEST.in adds `examples/` to the official release tarball (we use the GitHub auto-archive, so source URL unchanged; comment refreshed)
  - python version-string bump
- **sha256** = `7d998625d1035ac496d06a81117727647169422ee67b8889609f06fd5367c491` (auto-archive of `v3.7.1` tag).
- **Build number `1` → `0`** (reset on version bump).
- **No patch refresh needed.** The three carried patches target `CMakeLists.txt`, `python/triton/knobs.py`, and `python/triton/runtime/build.py` — none of which changed between 3.7.0 and 3.7.1 (verified against [upstream diff](https://github.com/triton-lang/triton/compare/v3.7.0...v3.7.1) — only 11 files modified, all unrelated to the patched files).

Variant matrix unchanged from PKG-14354: linux-64 × CUDA 13.0 × py3.10–3.14 (10 builds). aarch64 and win-64 stay skipped at the recipe level (aarch64 blocked on glibc 2.34/PBP infra per PKG-13219; win-64 awaits upstream support).

[PKG-15870]: https://anaconda.atlassian.net/browse/PKG-15870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ