### PR TITLE
experimental: enable linux-aarch64 build (glibc 2.34)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,16 @@
+# Triton on aarch64 only builds CUDA 13.0 — matches pytorch 2.12 aarch64
+# coverage (pkgs/main has no gpu_cuda129 builds for aarch64). x86_64 still
+# builds both 12.9 and 13.0 to match the aggregate default.
+cuda_compiler_version:
+  - 12.9                       # [linux and x86_64]
+  - 13.0                       # [linux]
+
+# Triton's bundled LLVM links symbols requiring glibc 2.34 on aarch64.
+# x86_64 builds get away with the build.sh __glibcxx_assert_fail linker
+# stub for the one missing symbol; aarch64's missing-symbol surface is
+# wider, so opt this arch up to the 2.34 sysroot floor. Shipped binaries
+# will require customer glibc >= 2.34 on aarch64 (Rocky 9 / Ubuntu 22.04+).
+# x86_64 stays on the aggregate default (2.28) — no shipping-policy change
+# for existing customers.
+c_stdlib_version:
+  - "2.34"                     # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,9 @@ build:
   number: 0
   # TODO: windows support should be available from next version;
   #       CPU-only support still under development
-  skip: true  # [win or cuda_compiler_version == "None"]
-  # We only use this (and can test this) for pytorch, linux + x86_64 + GPU.
-  # TODO: Await support on CI for aarch64 when 2.34 GLIBC (Rocky Linux 9) are availible to use upon release.
-  skip: true  # [not (linux and x86_64)]
+  skip: true  # [win or osx or cuda_compiler_version == "None"]
+  # aarch64 enabled experimentally — sysroot bumped to 2.34 (see local CBC)
+  # because triton's bundled LLVM needs symbols absent from glibc 2.28.
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
 
 requirements:


### PR DESCRIPTION
triton - experimental linux-aarch64 enablement (glibc 2.34)

**Destination channel:** defaults
**⚠️ DRAFT / PROBE PR** — no Jira ticket yet. If CI passes, we file the ticket under epic PKG-14944 and decide on shipping policy with Charles/Tyler. If CI fails, we learn the gap before paperwork.

### Links

- Related: [PKG-13219](https://anaconda.atlassian.net/browse/PKG-13219) — original aarch64 blocker (closed 2026-03 with "deliver pytorch without triton on aarch64"); revisiting now that the infra has shifted
- Infra prerequisites now landed:
  - [PKG-9994](https://anaconda.atlassian.net/browse/PKG-9994) — GLIBC 2.34 support epic (Ian Fitchet, Done 2026-05-29)
  - [PKG-11164](https://anaconda.atlassian.net/browse/PKG-11164) — CDT Rocky 9 aarch64 (Done)
  - [PKG-11161](https://anaconda.atlassian.net/browse/PKG-11161) — Rocky 9 docker images (Done)
  - [PKG-14891](https://anaconda.atlassian.net/browse/PKG-14891) — golden base images (Done)
- Verified `sysroot_linux-aarch64 2.34 h6c4afdf_0` is on pkgs/main

### Explanation of changes:

This PR is a CI probe to see whether the now-available glibc 2.34 sysroot is enough to unblock triton aarch64 in the PBP build env. If it builds and tests cleanly, we file the ticket and the team decides whether to ship.

- **`recipe/meta.yaml`:**
  - Drop the `[not (linux and x86_64)]` skip line. The remaining `[win or osx or cuda_compiler_version == "None"]` selector still gates Windows (upstream Linux-only), macOS (no NVIDIA CUDA on Apple Silicon), and the no-CUDA build slot.
- **`recipe/conda_build_config.yaml`** (new local override):
  - `cuda_compiler_version`: constrains aarch64 to `13.0` only. pytorch 2.12 aarch64 ships `gpu_cuda130_*` exclusively (no `gpu_cuda129_*`), so a triton aarch64 cuda129 build would be orphaned. x86_64 still gets both `12.9` and `13.0` (unchanged behavior).
  - `c_stdlib_version: "2.34" # [linux and aarch64]`: opt aarch64 up to the glibc 2.34 sysroot floor. Triton's bundled LLVM links symbols absent from glibc 2.28; the existing build.sh `__glibcxx_assert_fail` stub fixes the one symbol on x86_64, but aarch64's missing-symbol surface is wider. x86_64 stays on the aggregate default `2.28` — **no shipping-policy change for existing customers**.
- Build number unchanged (still `0`) — aarch64 is a different platform so 3.7.1 linux-64 artifacts on pkgs/main don't collide.
- Tests stay disabled via `abs.yaml --no-test` (pytorch circular dep, unchanged from 3.7.0/3.7.1).

### Expected variant matrix delta

| Platform | Before | After |
|---|---|---|
| linux-64 | cuda 12.9 + 13.0 × py3.10–3.14 = 10 builds | unchanged |
| linux-aarch64 | (skipped) | **cuda 13.0 × py3.10–3.14 = 5 new builds** |
| win-64 / osx-arm64 | (skipped) | unchanged |

### What we want CI to tell us

1. Does the linker resolve all symbols with the 2.34 sysroot, or are there still missing symbols beyond `__glibcxx_assert_fail`?
2. Does the bundled LLVM build correctly for `sbsa-linux` target on the PBP aarch64 worker?
3. Does the resulting wheel `pip install . -vv` complete on aarch64?

### Shipping policy gate (out of scope for this PR)

If CI passes, **before merging** we need explicit OK from Charles/Tyler on:
- Customer-side glibc ≥ 2.34 requirement for aarch64 triton (Rocky 9 / Ubuntu 22.04 / Debian 12+)
- Whether this should ride into the pytorch 2.13 epic (PKG-12883) for coordinated downstream rebuilds

[PKG-13219]: https://anaconda.atlassian.net/browse/PKG-13219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-9994]: https://anaconda.atlassian.net/browse/PKG-9994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-11164]: https://anaconda.atlassian.net/browse/PKG-11164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-11161]: https://anaconda.atlassian.net/browse/PKG-11161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14891]: https://anaconda.atlassian.net/browse/PKG-14891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ